### PR TITLE
增加对循环引用对象转换的支持

### DIFF
--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Employee.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Employee.java
@@ -23,7 +23,8 @@ public class Employee {
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private List<Employee> team;
-    @AutoMapping(target = "b")
+
+    @AutoMapping(target = "b.createBy.id", source = "a.createBy")
     private A a;
 
 }

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Employee.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Employee.java
@@ -1,0 +1,15 @@
+package io.github.linpeilie.model;
+
+import io.github.linpeilie.annotations.AutoMapper;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@AutoMapper(target = EmployeeDto.class)
+public class Employee {
+
+    private String name;
+    private Employee reportsTo;
+    private List<Employee> team;
+
+}

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Employee.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Employee.java
@@ -1,6 +1,7 @@
 package io.github.linpeilie.model;
 
 import io.github.linpeilie.annotations.AutoMapper;
+import io.github.linpeilie.annotations.AutoMapping;
 import java.util.List;
 import lombok.Data;
 
@@ -11,5 +12,7 @@ public class Employee {
     private String name;
     private Employee reportsTo;
     private List<Employee> team;
+    @AutoMapping(target = "b")
+    private A a;
 
 }

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/EmployeeDto.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/EmployeeDto.java
@@ -1,0 +1,15 @@
+package io.github.linpeilie.model;
+
+import io.github.linpeilie.annotations.AutoMapper;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@AutoMapper(target = Employee.class)
+public class EmployeeDto {
+
+    private String employeeName;
+    private EmployeeDto reportsTo;
+    private List<EmployeeDto> team;
+
+}

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/EmployeeDto.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/EmployeeDto.java
@@ -1,6 +1,7 @@
 package io.github.linpeilie.model;
 
 import io.github.linpeilie.annotations.AutoMapper;
+import io.github.linpeilie.annotations.AutoMapping;
 import java.util.List;
 import lombok.Data;
 
@@ -11,5 +12,7 @@ public class EmployeeDto {
     private String employeeName;
     private EmployeeDto reportsTo;
     private List<EmployeeDto> team;
+    @AutoMapping(target = "a")
+    private B b;
 
 }

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/EmployeeDto.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/EmployeeDto.java
@@ -1,14 +1,11 @@
 package io.github.linpeilie.model;
 
-import io.github.linpeilie.annotations.AutoMapper;
-import io.github.linpeilie.annotations.AutoMapping;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @Data
-@AutoMapper(target = Employee.class)
 public class EmployeeDto {
 
     private String employeeName;
@@ -20,7 +17,7 @@ public class EmployeeDto {
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private List<EmployeeDto> team;
-    @AutoMapping(target = "a")
+
     private B b;
 
 }

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Product.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/Product.java
@@ -1,0 +1,21 @@
+package io.github.linpeilie.model;
+
+import io.github.linpeilie.annotations.AutoMapper;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@AutoMapper(target = ProductDto.class)
+public class Product {
+
+    private Long id;
+
+    private String name;
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<ProductProperty> productProperties;
+}

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/ProductDto.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/ProductDto.java
@@ -1,0 +1,19 @@
+package io.github.linpeilie.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+public class ProductDto {
+
+    private Long id;
+
+    private String name;
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private List<ProductPropertyDto> productProperties;
+}

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/ProductProperty.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/ProductProperty.java
@@ -1,0 +1,19 @@
+package io.github.linpeilie.model;
+
+import io.github.linpeilie.annotations.AutoMapper;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@AutoMapper(target = ProductPropertyDto.class)
+public class ProductProperty {
+
+    private Long id;
+
+    private String name;
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Product product;
+}

--- a/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/ProductPropertyDto.java
+++ b/example/spring-boot-with-lombok/src/main/java/io/github/linpeilie/model/ProductPropertyDto.java
@@ -1,0 +1,17 @@
+package io.github.linpeilie.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+public class ProductPropertyDto {
+
+    private Long id;
+
+    private String name;
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private ProductDto product;
+}

--- a/example/spring-boot-with-lombok/src/test/java/io/github/linpeilie/QuickStartTest.java
+++ b/example/spring-boot-with-lombok/src/test/java/io/github/linpeilie/QuickStartTest.java
@@ -290,6 +290,12 @@ public class QuickStartTest {
         memberDto2.setReportsTo(teamLeaderDto);
         teamLeaderDto.setTeam(Arrays.asList(memberDto1, memberDto2));
 
+        B b = new B();
+        C c = new C();
+        c.setId(99L);
+        b.setCreateBy(c);
+        teamLeaderDto.setB(b);
+
         Employee teamLead = converter.convert(teamLeaderDto, Employee.class, true);
 
         Assert.notNull(teamLead);
@@ -298,6 +304,7 @@ public class QuickStartTest {
         Assert.equals(team.size(), 2);
         Assert.equals(team.get(0).getReportsTo(), teamLead);
         Assert.equals(team.get(1).getReportsTo(), teamLead);
+        Assert.equals(teamLead.getA().getCreateBy(), 99L);
 
 
         Employee teamLeader = new Employee();
@@ -312,6 +319,10 @@ public class QuickStartTest {
         member2.setReportsTo(teamLeader);
         teamLeader.setTeam(Arrays.asList(member1, member2));
 
+        A a = new A();
+        a.setCreateBy(99L);
+        teamLeader.setA(a);
+
         EmployeeDto teamLeadDto = converter.convert(teamLeader, EmployeeDto.class, true);
 
         Assert.notNull(teamLeadDto);
@@ -320,6 +331,7 @@ public class QuickStartTest {
         Assert.equals(teamDto.size(), 2);
         Assert.equals(teamDto.get(0).getReportsTo(), teamLeadDto);
         Assert.equals(teamDto.get(1).getReportsTo(), teamLeadDto);
+        Assert.equals(teamLeadDto.getB().getCreateBy().getId(), 99L);
     }
 
 }

--- a/example/spring-boot-with-lombok/src/test/java/io/github/linpeilie/QuickStartTest.java
+++ b/example/spring-boot-with-lombok/src/test/java/io/github/linpeilie/QuickStartTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest
 public class QuickStartTest {
 
@@ -250,49 +248,78 @@ public class QuickStartTest {
     }
 
     @Test
+    public void OneToManyTest() {
+
+        Product product = new Product();
+        product.setId(1L);
+        product.setName("Product");
+
+        ProductProperty productProperty1 = new ProductProperty();
+        productProperty1.setId(1L);
+        productProperty1.setName("ProductProperty1");
+        productProperty1.setProduct(product);
+
+        ProductProperty productProperty2 = new ProductProperty();
+        productProperty2.setId(2L);
+        productProperty2.setName("ProductProperty2");
+        productProperty2.setProduct(product);
+
+        product.setProductProperties(Arrays.asList(productProperty1, productProperty2));
+
+        ProductDto productDto = converter.convert(product, ProductDto.class, true);
+
+        Assert.equals(productDto.getProductProperties().size(), 2);
+        Assert.equals(productDto.getProductProperties().get(0).getId(), 1L);
+        Assert.equals(productDto.getProductProperties().get(1).getId(), 2L);
+        Assert.equals(productDto.getProductProperties().get(0).getProduct(), productDto);
+        Assert.equals(productDto.getProductProperties().get(1).getProduct(), productDto);
+    }
+
+    @Test
     public void cycleMappingTest() {
 
         EmployeeDto teamLeaderDto = new EmployeeDto();
-        teamLeaderDto.setEmployeeName( "Group Leader" );
-        teamLeaderDto.setReportsTo( null );
+        teamLeaderDto.setEmployeeName("Group Leader");
+        teamLeaderDto.setReportsTo(null);
 
         EmployeeDto memberDto1 = new EmployeeDto();
-        memberDto1.setEmployeeName( "Member1" );
-        memberDto1.setReportsTo( teamLeaderDto );
+        memberDto1.setEmployeeName("Member1");
+        memberDto1.setReportsTo(teamLeaderDto);
         EmployeeDto memberDto2 = new EmployeeDto();
-        memberDto2.setEmployeeName( "Member2" );
-        memberDto2.setReportsTo( teamLeaderDto );
-        teamLeaderDto.setTeam( Arrays.asList( memberDto1, memberDto2 ) );
+        memberDto2.setEmployeeName("Member2");
+        memberDto2.setReportsTo(teamLeaderDto);
+        teamLeaderDto.setTeam(Arrays.asList(memberDto1, memberDto2));
 
-        Employee teamLead = converter.convert( teamLeaderDto, Employee.class, true );
+        Employee teamLead = converter.convert(teamLeaderDto, Employee.class, true);
 
-        assertThat( teamLead ).isNotNull();
-        assertThat( teamLead.getReportsTo() ).isNull();
+        Assert.notNull(teamLead);
+        Assert.isNull(teamLead.getReportsTo());
         List<Employee> team = teamLead.getTeam();
-        assertThat( team ).hasSize( 2 );
-        assertThat( team ).extracting( "reportsTo" ).containsExactly( teamLead, teamLead );
-
+        Assert.equals(team.size(), 2);
+        Assert.equals(team.get(0).getReportsTo(), teamLead);
+        Assert.equals(team.get(1).getReportsTo(), teamLead);
 
 
         Employee teamLeader = new Employee();
-        teamLeader.setName( "Group Leader" );
-        teamLeader.setReportsTo( null );
+        teamLeader.setName("Group Leader");
+        teamLeader.setReportsTo(null);
 
         Employee member1 = new Employee();
-        member1.setName( "Member1" );
-        member1.setReportsTo( teamLeader );
+        member1.setName("Member1");
+        member1.setReportsTo(teamLeader);
         Employee member2 = new Employee();
-        member2.setName( "Member2" );
-        member2.setReportsTo( teamLeader );
-        teamLeader.setTeam( Arrays.asList( member1, member2 ) );
+        member2.setName("Member2");
+        member2.setReportsTo(teamLeader);
+        teamLeader.setTeam(Arrays.asList(member1, member2));
 
-        EmployeeDto teamLeadDto = converter.convert( teamLeader, EmployeeDto.class, true );
+        EmployeeDto teamLeadDto = converter.convert(teamLeader, EmployeeDto.class, true);
 
-        assertThat( teamLeadDto ).isNotNull();
-        assertThat( teamLeadDto.getReportsTo() ).isNull();
+        Assert.notNull(teamLeadDto);
+        Assert.isNull(teamLeadDto.getReportsTo());
         List<EmployeeDto> teamDto = teamLeadDto.getTeam();
-        assertThat( teamDto ).hasSize( 2 );
-        assertThat( teamDto ).extracting( "reportsTo" ).containsExactly( teamLeadDto, teamLeadDto );
+        Assert.equals(teamDto.size(), 2);
+        Assert.equals(teamDto.get(0).getReportsTo(), teamLeadDto);
+        Assert.equals(teamDto.get(1).getReportsTo(), teamLeadDto);
     }
 
 }

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/AutoMapperProperties.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/AutoMapperProperties.java
@@ -29,11 +29,15 @@ public class AutoMapperProperties {
 
     private static String adapterClassName = DEFAULT_ADAPTER_CLASS_NAME;
 
+    private static String cycleAvoidingAdapterClassName = DEFAULT_CYCLE_AVOIDING_ADAPTER_CLASS_NAME;
+
     private static String mapAdapterClassName = DEFAULT_MAP_ADAPTER_CLASS_NAME;
 
     private static String autoConfigPackage = DEFAULT_BASE_PACKAGE;
 
     private static String autoMapperConfigClassName = AUTO_MAPPER_CONFIG_CLASS_NAME;
+
+    private static String autoCycleAvoidingMapperConfigClassName = AUTO_CYCLE_AVOIDING_MAPPER_CONFIG_CLASS_NAME;
 
     private static String autoMapMapperConfigClassName = AUTO_MAP_MAPPER_CONFIG_CLASS_NAME;
 
@@ -55,6 +59,14 @@ public class AutoMapperProperties {
 
     public static void setAdapterClassName(final String adapterClassName) {
         AutoMapperProperties.adapterClassName = adapterClassName;
+    }
+
+    public static String getCycleAvoidingAdapterClassName() {
+        return cycleAvoidingAdapterClassName;
+    }
+
+    public static void setCycleAvoidingAdapterClassName(final String cycleAvoidingAdapterClassName) {
+        AutoMapperProperties.cycleAvoidingAdapterClassName = cycleAvoidingAdapterClassName;
     }
 
     public static String getMapAdapterClassName() {
@@ -79,6 +91,14 @@ public class AutoMapperProperties {
 
     public static void setAutoMapperConfigClassName(String autoMapperConfigClassName) {
         AutoMapperProperties.autoMapperConfigClassName = autoMapperConfigClassName;
+    }
+
+    public static String getCycleAvoidingConfigClassName() {
+        return autoCycleAvoidingMapperConfigClassName;
+    }
+
+    public static void setAutoCycleAvoidingMapperConfigClassName(String autoCycleAvoidingMapperConfigClassName) {
+        AutoMapperProperties.autoCycleAvoidingMapperConfigClassName = autoCycleAvoidingMapperConfigClassName;
     }
 
     public static String getMapConfigClassName() {

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/Constants.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/Constants.java
@@ -11,9 +11,13 @@ public class Constants {
 
     public static final String DEFAULT_ADAPTER_CLASS_NAME = "ConvertMapperAdapter";
 
+    public static final String DEFAULT_CYCLE_AVOIDING_ADAPTER_CLASS_NAME = "CycleAvoidingConvertMapperAdapter";
+
     public static final String DEFAULT_MAP_ADAPTER_CLASS_NAME = "MapConvertMapperAdapter";
 
     public static final String AUTO_MAPPER_CONFIG_CLASS_NAME = "AutoMapperConfig";
+
+    public static final String AUTO_CYCLE_AVOIDING_MAPPER_CONFIG_CLASS_NAME = "AutoCycleAvoidingMapperConfig";
 
     public static final String AUTO_MAP_MAPPER_CONFIG_CLASS_NAME = "AutoMapMapperConfig";
 

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/generator/DefaultAdapterMapperGenerator.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/generator/DefaultAdapterMapperGenerator.java
@@ -28,8 +28,10 @@ public class DefaultAdapterMapperGenerator extends AbstractAdapterMapperGenerato
 
     @Override
     protected CodeBlock proxyMethodTarget(final AbstractAdapterMethodMetadata adapterMethodMetadata) {
-        return CodeBlock.of("return ($T.getMapper($T.class)).$N($N);",
-            ClassName.get("org.mapstruct.factory", "Mappers"), adapterMethodMetadata.getMapper(),
-            adapterMethodMetadata.getMapperMethodName(), "param");
+        return !adapterMethodMetadata.isCycleAvoiding() ?
+            CodeBlock.of("return ($T.getMapper($T.class)).$N($N);", ClassName.get("org.mapstruct.factory", "Mappers"),
+                adapterMethodMetadata.getMapper(), adapterMethodMetadata.getMapperMethodName(), "param") :
+            CodeBlock.of("return ($T.getMapper($T.class)).$N($N, $N);", ClassName.get("org.mapstruct.factory", "Mappers"),
+                adapterMethodMetadata.getMapper(), adapterMethodMetadata.getMapperMethodName(), "param", "context");
     }
 }

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/generator/IocAdapterMapperGenerator.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/generator/IocAdapterMapperGenerator.java
@@ -48,11 +48,11 @@ public abstract class IocAdapterMapperGenerator extends AbstractAdapterMapperGen
 
     @Override
     protected CodeBlock proxyMethodTarget(AbstractAdapterMethodMetadata adapterMethodMetadata) {
-        return CodeBlock.builder()
-            .add("return $N.$N($N);", firstWordToLower(adapterMethodMetadata.getMapper().simpleName()),
-                adapterMethodMetadata.getMapperMethodName(),
-                "param")
-            .build();
+        return !adapterMethodMetadata.isCycleAvoiding() ?
+            CodeBlock.builder().add("return $N.$N($N);", firstWordToLower(adapterMethodMetadata.getMapper().simpleName()),
+                adapterMethodMetadata.getMapperMethodName(), "param").build() :
+            CodeBlock.builder().add("return $N.$N($N, $N);", firstWordToLower(adapterMethodMetadata.getMapper().simpleName()),
+                adapterMethodMetadata.getMapperMethodName(), "param", "context").build();
     }
 
 }

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AbstractAdapterMethodMetadata.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AbstractAdapterMethodMetadata.java
@@ -8,11 +8,14 @@ public abstract class AbstractAdapterMethodMetadata {
     public AbstractAdapterMethodMetadata(final TypeName source, ClassName mapper) {
         this.source = source;
         this.mapper = mapper;
+        this.cycleAvoiding = false;
     }
 
     protected final TypeName source;
 
     protected final ClassName mapper;
+
+    protected boolean cycleAvoiding;
 
     public abstract String getMethodName();
 
@@ -26,6 +29,10 @@ public abstract class AbstractAdapterMethodMetadata {
 
     public ClassName getMapper() {
         return mapper;
+    }
+
+    public boolean isCycleAvoiding() {
+        return cycleAvoiding;
     }
 
     public boolean isStatic() {

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AbstractMapperMetadata.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AbstractMapperMetadata.java
@@ -8,6 +8,8 @@ public abstract class AbstractMapperMetadata {
 
     protected ClassName sourceClassName;
 
+    protected boolean cycleAvoiding;
+
     public String mapperPackage() {
         return StringUtils.isNotEmpty(AutoMapperProperties.getMapperPackage())
                ? AutoMapperProperties.getMapperPackage() : sourceClassName.packageName();
@@ -25,6 +27,14 @@ public abstract class AbstractMapperMetadata {
 
     public void setSourceClassName(final ClassName sourceClassName) {
         this.sourceClassName = sourceClassName;
+    }
+
+    public boolean isCycleAvoiding() {
+        return cycleAvoiding;
+    }
+
+    public void setCycleAvoiding(boolean cycleAvoiding) {
+        this.cycleAvoiding = cycleAvoiding;
     }
 
 }

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AdapterEnumMethodMetadata.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AdapterEnumMethodMetadata.java
@@ -12,10 +12,12 @@ public class AdapterEnumMethodMetadata extends AbstractAdapterMethodMetadata {
     public AdapterEnumMethodMetadata(final TypeName source,
         final ClassName mapper,
         final String proxyTargetMethodName,
-        final TypeName returnType) {
+        final TypeName returnType,
+        boolean cycleAvoiding) {
         super(source, mapper);
         this.proxyTargetMethodName = proxyTargetMethodName;
         this.returnType = returnType;
+        this.cycleAvoiding = cycleAvoiding;
     }
 
     @Override

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AdapterMethodMetadata.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AdapterMethodMetadata.java
@@ -4,15 +4,16 @@ import com.squareup.javapoet.ClassName;
 
 public class AdapterMethodMetadata extends AbstractAdapterMethodMetadata {
 
-    private AdapterMethodMetadata(final ClassName source, final ClassName target, ClassName mapper) {
+    private AdapterMethodMetadata(final ClassName source, final ClassName target, ClassName mapper, boolean cycleAvoiding) {
         super(source, mapper);
         this.target = target;
+        this.cycleAvoiding = cycleAvoiding;
     }
 
     private final ClassName target;
 
-    public static AdapterMethodMetadata newInstance(ClassName source, ClassName target, ClassName mapper) {
-        return new AdapterMethodMetadata(source, target, mapper);
+    public static AdapterMethodMetadata newInstance(ClassName source, ClassName target, ClassName mapper, boolean cycleAvoiding) {
+        return new AdapterMethodMetadata(source, target, mapper, cycleAvoiding);
     }
 
     @Override

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AutoEnumMapperMetadata.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AutoEnumMapperMetadata.java
@@ -1,6 +1,5 @@
 package io.github.linpeilie.processor.metadata;
 
-import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
 
 public class AutoEnumMapperMetadata extends AbstractMapperMetadata {
@@ -27,7 +26,7 @@ public class AutoEnumMapperMetadata extends AbstractMapperMetadata {
 
     @Override
     public String mapperName() {
-        return sourceClassName.simpleName() + "Mapper";
+        return sourceClassName.simpleName() + (cycleAvoiding ? "CycleAvoiding" : "") + "Mapper";
     }
 
     public String toEnumMethodName() {

--- a/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AutoMapperMetadata.java
+++ b/mapstruct-plus-processor/src/main/java/io/github/linpeilie/processor/metadata/AutoMapperMetadata.java
@@ -27,8 +27,10 @@ public class AutoMapperMetadata extends AbstractMapperMetadata {
 
     private boolean reverseConvertGenerate;
 
+    private boolean cycleAvoiding;
+
     public String mapperName() {
-        return sourceClassName.simpleName() + "To" + targetClassName.simpleName() + "Mapper";
+        return sourceClassName.simpleName() + "To" + targetClassName.simpleName() + (cycleAvoiding ? "CycleAvoiding" : "") + "Mapper";
     }
 
     public ClassName getTargetClassName() {
@@ -112,5 +114,13 @@ public class AutoMapperMetadata extends AbstractMapperMetadata {
 
     public void setConvertGenerate(final boolean convertGenerate) {
         this.convertGenerate = convertGenerate;
+    }
+
+    public boolean isCycleAvoiding() {
+        return cycleAvoiding;
+    }
+
+    public void setCycleAvoiding(boolean cycleAvoiding) {
+        this.cycleAvoiding = cycleAvoiding;
     }
 }

--- a/mapstruct-plus-spring-boot-starter/src/main/java/io/github/linpeilie/mapstruct/SpringConverterFactory.java
+++ b/mapstruct-plus-spring-boot-starter/src/main/java/io/github/linpeilie/mapstruct/SpringConverterFactory.java
@@ -1,6 +1,7 @@
 package io.github.linpeilie.mapstruct;
 
 import io.github.linpeilie.AbstractCachedConverterFactory;
+import io.github.linpeilie.BaseCycleAvoidingMapper;
 import io.github.linpeilie.BaseMapMapper;
 import io.github.linpeilie.BaseMapper;
 import org.springframework.context.ApplicationContext;
@@ -23,6 +24,17 @@ public class SpringConverterFactory extends AbstractCachedConverterFactory {
             return null;
         }
         return (BaseMapper<S, T>) applicationContext.getBean(beanNames[0]);
+    }
+
+    @Override
+    public <S, T> BaseCycleAvoidingMapper<S, T> findCycleAvoidingMapper(final Class<S> sourceType, final Class<T> targetType) {
+        ResolvableType type = ResolvableType.forClassWithGenerics(
+            BaseCycleAvoidingMapper.class, sourceType, targetType);
+        String[] beanNames = applicationContext.getBeanNamesForType(type);
+        if (beanNames.length == 0) {
+            return null;
+        }
+        return (BaseCycleAvoidingMapper<S, T>) applicationContext.getBean(beanNames[0]);
     }
 
     @Override

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/AbstractCachedConverterFactory.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/AbstractCachedConverterFactory.java
@@ -6,6 +6,8 @@ public abstract class AbstractCachedConverterFactory implements ConverterFactory
 
     private final ConcurrentHashMap<String, BaseMapper> mapperMap = new ConcurrentHashMap<>();
 
+    private final ConcurrentHashMap<String, BaseCycleAvoidingMapper> cycleAvoidingMapperMap = new ConcurrentHashMap<>();
+
     private final ConcurrentHashMap<String, BaseMapMapper> mapMapperMap = new ConcurrentHashMap<>();
 
     @Override
@@ -20,6 +22,23 @@ public abstract class AbstractCachedConverterFactory implements ConverterFactory
         final BaseMapper mapper = findMapper(source, target);
         if (mapper != null) {
             mapperMap.put(key, mapper);
+            return mapper;
+        }
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <S, T> BaseCycleAvoidingMapper<S, T> getCycleAvoidingMapper(final Class<S> sourceType, final Class<T> targetType) {
+        final Class<?> source = wrapperClass(sourceType);
+        final Class<?> target = wrapperClass(targetType);
+        final String key = key(source, target);
+        if (cycleAvoidingMapperMap.containsKey(key)) {
+            return cycleAvoidingMapperMap.get(key);
+        }
+        final BaseCycleAvoidingMapper mapper = findCycleAvoidingMapper(source, target);
+        if (mapper != null) {
+            cycleAvoidingMapperMap.put(key, mapper);
             return mapper;
         }
         return null;
@@ -45,6 +64,8 @@ public abstract class AbstractCachedConverterFactory implements ConverterFactory
     }
 
     protected abstract <S, T> BaseMapper findMapper(final Class<S> source, final Class<T> target);
+
+    protected abstract <S, T> BaseCycleAvoidingMapper findCycleAvoidingMapper(final Class<S> source, final Class<T> target);
 
     protected abstract <S> BaseMapMapper findMapMapper(final Class<?> source);
 

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/BaseCycleAvoidingMapper.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/BaseCycleAvoidingMapper.java
@@ -1,0 +1,24 @@
+package io.github.linpeilie;
+
+import cn.hutool.core.collection.CollectionUtil;
+import org.mapstruct.Context;
+import org.mapstruct.MappingTarget;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public interface BaseCycleAvoidingMapper<S, T> {
+
+    T convert(S source, @Context CycleAvoidingMappingContext context);
+
+    T convert(S source, @MappingTarget T target, @Context CycleAvoidingMappingContext context);
+
+    default List<T> convert(List<S> sourceList, @Context CycleAvoidingMappingContext context) {
+        if (CollectionUtil.isEmpty(sourceList)) {
+            return new ArrayList<>();
+        }
+        return sourceList.stream().map(source -> convert(source, context)).collect(Collectors.toList());
+    }
+
+}

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/Converter.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/Converter.java
@@ -10,6 +10,16 @@ public class Converter {
 
     private final ConverterFactory converterFactory;
 
+    private boolean defaultCycleAvoiding;
+
+    public boolean isDefaultCycleAvoiding() {
+        return defaultCycleAvoiding;
+    }
+
+    public void setDefaultCycleAvoiding(boolean defaultCycleAvoiding) {
+        this.defaultCycleAvoiding = defaultCycleAvoiding;
+    }
+
     public Converter() {
         this.converterFactory = new DefaultConverterFactory();
     }
@@ -20,12 +30,25 @@ public class Converter {
 
     @SuppressWarnings("unchecked")
     public <S, T> T convert(S source, Class<T> targetType) {
+        return convert(source, targetType, defaultCycleAvoiding);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <S, T> T convert(S source, Class<T> targetType, boolean cycleAvoiding) {
         if (source == null) {
             return null;
         }
-        BaseMapper<S, T> mapper = (BaseMapper<S, T>) converterFactory.getMapper(source.getClass(), targetType);
-        if (mapper != null) {
-            return mapper.convert(source);
+        if (!cycleAvoiding) {
+            BaseMapper<S, T> mapper = (BaseMapper<S, T>) converterFactory.getMapper(source.getClass(), targetType);
+            if (mapper != null) {
+                return mapper.convert(source);
+            }
+        } else {
+            BaseCycleAvoidingMapper<S, T> mapper = (BaseCycleAvoidingMapper<S, T>) converterFactory
+                .getCycleAvoidingMapper(source.getClass(), targetType);
+            if (mapper != null) {
+                return mapper.convert(source, new CycleAvoidingMappingContext());
+            }
         }
         throw new ConvertException(
             "cannot find converter from " + source.getClass().getSimpleName() + " to " + targetType.getSimpleName());
@@ -33,25 +56,42 @@ public class Converter {
 
     @SuppressWarnings("unchecked")
     public <S, T> T convert(S source, T target) {
+        return convert(source, target, defaultCycleAvoiding);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <S, T> T convert(S source, T target, boolean cycleAvoiding) {
         if (source == null) {
             return null;
         }
         if (target == null) {
             return null;
         }
-        BaseMapper<S, T> mapper = (BaseMapper<S, T>) converterFactory.getMapper(source.getClass(), target.getClass());
-        if (mapper != null) {
-            return mapper.convert(source, target);
+        if (!cycleAvoiding) {
+            BaseMapper<S, T> mapper = (BaseMapper<S, T>) converterFactory.getMapper(source.getClass(), target.getClass());
+            if (mapper != null) {
+                return mapper.convert(source, target);
+            }
+        } else {
+            BaseCycleAvoidingMapper<S, T> mapper = (BaseCycleAvoidingMapper<S, T>) converterFactory
+                .getCycleAvoidingMapper(source.getClass(), target.getClass());
+            if (mapper != null) {
+                return mapper.convert(source, target, new CycleAvoidingMappingContext());
+            }
         }
         throw new ConvertException("cannot find converter from " + source.getClass().getSimpleName() + " to " +
                                    target.getClass().getSimpleName());
     }
 
     public <S, T> List<T> convert(List<S> source, Class<T> targetType) {
+        return convert(source, targetType, defaultCycleAvoiding);
+    }
+
+    public <S, T> List<T> convert(List<S> source, Class<T> targetType, boolean cycleAvoiding) {
         if (source == null || source.size() == 0) {
             return new ArrayList<>();
         }
-        return source.stream().map(item -> convert(item, targetType)).collect(Collectors.toList());
+        return source.stream().map(item -> convert(item, targetType, cycleAvoiding)).collect(Collectors.toList());
     }
 
     public <T> T convert(Map<String, Object> map, Class<T> target) {

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/ConverterFactory.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/ConverterFactory.java
@@ -4,6 +4,8 @@ public interface ConverterFactory {
 
     <S, T> BaseMapper<S, T> getMapper(Class<S> sourceType, Class<T> targetType);
 
+    <S, T> BaseCycleAvoidingMapper<S, T> getCycleAvoidingMapper(Class<S> sourceType, Class<T> targetType);
+
     <S> BaseMapMapper<S> getMapMapper(Class<S> sourceType);
 
 }

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/CycleAvoidingMappingContext.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/CycleAvoidingMappingContext.java
@@ -1,0 +1,21 @@
+package io.github.linpeilie;
+
+import cn.hutool.core.map.multi.RowKeyTable;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.TargetType;
+
+public class CycleAvoidingMappingContext {
+
+    private RowKeyTable<Object, Class, Object> knownInstances = new RowKeyTable<>();
+
+    @BeforeMapping
+    public <T> T getMappedInstance(Object source, @TargetType Class<T> targetType) {
+        return (T) knownInstances.get(source, targetType);
+    }
+
+    @BeforeMapping
+    public void storeMappedInstance(Object source, @MappingTarget Object target) {
+        knownInstances.put(source, target.getClass(), target);
+    }
+}

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/DefaultConverterFactory.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/DefaultConverterFactory.java
@@ -83,6 +83,10 @@ public class DefaultConverterFactory extends AbstractCachedConverterFactory {
         return source.getSimpleName() + "To" + target.getSimpleName() + "Mapper";
     }
 
+    private String getCycleAvoidingMapperClassName(Class<?> source, Class<?> target) {
+        return source.getSimpleName() + "To" + target.getSimpleName() + "CycleAvoidingMapper";
+    }
+
     private String getMapMapperClassName(Class<?> source) {
         return "MapTo" + source.getSimpleName() + "Mapper";
     }
@@ -99,6 +103,18 @@ public class DefaultConverterFactory extends AbstractCachedConverterFactory {
         try {
             final Class<?> mapperClass = Class.forName(getMapperPackage(sourceType) + "." + mapperClassName);
             return (BaseMapper<S, T>) Mappers.getMapper(mapperClass);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <S, T> BaseCycleAvoidingMapper<S, T> findCycleAvoidingMapper(final Class<S> sourceType, final Class<T> targetType) {
+        final String mapperClassName = getCycleAvoidingMapperClassName(sourceType, targetType);
+        try {
+            final Class<?> mapperClass = Class.forName(getMapperPackage(sourceType) + "." + mapperClassName);
+            return (BaseCycleAvoidingMapper<S, T>) Mappers.getMapper(mapperClass);
         } catch (ClassNotFoundException e) {
             return null;
         }

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/MapperConfig.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/MapperConfig.java
@@ -69,6 +69,12 @@ public @interface MapperConfig {
     String adapterClassName() default "";
 
     /**
+     * 默认类名为：CycleAvoidingConvertMapperAdapter
+     * @return CycleAvoidingConvertAdapterClass 类名
+     */
+    String cycleAvoidingAdapterClassName() default "";
+
+    /**
      * 默认类名为：MapConvertMapperAdapter
      * @return MapConvertAdapterClass 类名
      */
@@ -89,6 +95,14 @@ public @interface MapperConfig {
      * @return  AutoMapperConfig 类名
      */
     String autoMapperConfigClassName() default "";
+
+    /**
+     * MapStructPlus 所生成的配置 CycleAvoiding 类转换的配置类名
+     * <br>
+     * 默认类名为 AutoCycleAvoidingMapperConfig
+     * @return  AutoCycleAvoidingMapperConfig 类名
+     */
+    String autoCycleAvoidingMapperConfigClassName() default "";
 
     /**
      * MapStructPlus 所生成的配置 Map 与对象转换的配置类名


### PR DESCRIPTION
实现原理参考官方样例：https://github.com/mapstruct/mapstruct-examples/tree/main/mapstruct-mapping-with-cycles

增加了BaseCycleAvoidingMapper，与BaseMapper区别是转换方法增加了通过@Context注解的CycleAvoidingMappingContext参数，通过CycleAvoidingMappingContext处理循环引用。

使用方法：
Converter.convert()支持传入cycleAvoiding参数，true表示处理循环引用，false表示不处理循环引用，默认为false。
```
public <S, T> T convert(S source, Class<T> targetType) {} //按默认设置决定是否处理循环引用，不设置默认不处理
public <S, T> T convert(S source, Class<T> targetType, boolean cycleAvoiding) {} //指定是否处理循环引用
public <S, T> T convert(S source, T target) {} //按默认设置决定是否处理循环引用，不设置默认不处理
public <S, T> T convert(S source, T target, boolean cycleAvoiding) {} //指定是否处理循环引用
public <S, T> List<T> convert(List<S> source, Class<T> targetType) {} //按默认设置决定是否处理循环引用，不设置默认不处理
public <S, T> List<T> convert(List<S> source, Class<T> targetType, boolean cycleAvoiding) {} //指定是否处理循环引用
```
也可以在初始化Converter时通过setDefaultCycleAvoiding()修改默认的cycleAvoiding，如：
```
@Bean
public Converter converter(ConverterFactory converterFactory) {
    Converter converter = new Converter(converterFactory);
    converter.setDefaultCycleAvoiding(true);
    return converter;
}
```