### PR TITLE
feat(processor): 支持在注解上使用 @AutoMapping- 新增处理注解上存在 @AutoMapping 的逻辑

### DIFF
--- a/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/AutoMapping.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/AutoMapping.java
@@ -18,7 +18,7 @@ import org.mapstruct.control.MappingControl;
 
 import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
 
-@Target({ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.METHOD,ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.CLASS)
 public @interface AutoMapping {
 


### PR DESCRIPTION
- 修改 @AutoMapping 注解，增加对 ElementType.ANNOTATION_TYPE 的支持 可以实现如下效果：
```java
//新增dto使用注解，自动将当前用户映射到创建人字段
@AutoMapping(source = "operatorUserId", target = "createBy")
 public @interface CreateMapper {
}
```

```java
// 更新dto使用注解，自动将当前用户映射到updateBy字段
@AutoMapping(source = "operatorUserId", target = "updateBy")
 public @interface UpdateMapper{

}
```
这样就可以将基类dto中的operatorUserId根据dto的不同，映射到对应的不同字段上面