### PR TITLE
可重复配置调整

### DIFF
--- a/example/quick-start/src/main/java/io/github/linpeilie/model/UserQuery.java
+++ b/example/quick-start/src/main/java/io/github/linpeilie/model/UserQuery.java
@@ -1,0 +1,37 @@
+package io.github.linpeilie.model;
+
+import io.github.linpeilie.annotations.AutoMapper;
+import io.github.linpeilie.annotations.AutoMapping;
+import io.github.linpeilie.annotations.ReverseAutoMapping;
+
+/**
+ * @author lipanre
+ */
+@AutoMapper(target = User.class)
+@AutoMapper(target = UserDto.class)
+public class UserQuery {
+
+    @AutoMapping(targetClass = User.class, target = "username")
+    @AutoMapping(targetClass = UserDto.class, target = "username")
+    private String name;
+
+    @ReverseAutoMapping(targetClass = User.class, source = "age")
+    @ReverseAutoMapping(targetClass = UserDto.class, source = "age")
+    private int age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/example/quick-start/src/test/java/io/github/linpeilie/QuickStartTest.java
+++ b/example/quick-start/src/test/java/io/github/linpeilie/QuickStartTest.java
@@ -1,13 +1,8 @@
 package io.github.linpeilie;
 
 import cn.hutool.core.date.DateUtil;
-import io.github.linpeilie.model.Goods;
-import io.github.linpeilie.model.GoodsDto;
-import io.github.linpeilie.model.GoodsStateEnum;
-import io.github.linpeilie.model.MapModelA;
-import io.github.linpeilie.model.User;
-import io.github.linpeilie.model.UserDto;
-import io.github.linpeilie.model.UserVO;
+import io.github.linpeilie.model.*;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -15,6 +10,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class QuickStartTest {
@@ -144,6 +141,25 @@ public class QuickStartTest {
         goodsDto1.setState(1);
         final Goods goods1 = converter.convert(goodsDto1, Goods.class);
         System.out.println(goods1);
+    }
+
+    @Test
+    public void multiMapperDeclareTest() {
+        User user = new User();
+        user.setUsername("testName");
+        user.setAge(12);
+
+        UserQuery userQuery1 = converter.convert(user, UserQuery.class);
+        Assertions.assertEquals("testName", userQuery1.getName());
+        Assertions.assertEquals(12, userQuery1.getAge());
+
+        UserDto userDto = new UserDto();
+        userDto.setUsername("testName2");
+        userDto.setAge(18);
+
+        UserQuery userQuery2 = converter.convert(userDto, UserQuery.class);
+        Assertions.assertEquals("testName2", userQuery2.getName());
+        Assertions.assertEquals(18, userQuery2.getAge());
     }
 
 }

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/AutoMapper.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/AutoMapper.java
@@ -1,10 +1,7 @@
 package io.github.linpeilie.annotations;
 
-import java.lang.annotation.Annotation;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
+
 import org.mapstruct.BeanMapping;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.IterableMapping;
@@ -23,6 +20,7 @@ import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
+@Repeatable(AutoMappers.class)
 public @interface AutoMapper {
 
     Class<?> target();

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/AutoMapping.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/AutoMapping.java
@@ -1,11 +1,9 @@
 package io.github.linpeilie.annotations;
 
 import io.github.linpeilie.DefaultMapping;
-import java.lang.annotation.Annotation;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+
+import java.lang.annotation.*;
+
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Condition;
 import org.mapstruct.Mapper;
@@ -20,6 +18,7 @@ import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
 
 @Target({ElementType.FIELD, ElementType.METHOD,ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.CLASS)
+@Repeatable(AutoMappings.class)
 public @interface AutoMapping {
 
     Class<?> targetClass() default DefaultMapping.class;

--- a/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/ReverseAutoMapping.java
+++ b/mapstruct-plus/src/main/java/io/github/linpeilie/annotations/ReverseAutoMapping.java
@@ -1,11 +1,9 @@
 package io.github.linpeilie.annotations;
 
 import io.github.linpeilie.DefaultMapping;
-import java.lang.annotation.Annotation;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+
+import java.lang.annotation.*;
+
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Condition;
 import org.mapstruct.Mapper;
@@ -35,6 +33,7 @@ import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
  */
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.CLASS)
+@Repeatable(ReverseAutoMappings.class)
 public @interface ReverseAutoMapping {
 
 


### PR DESCRIPTION
你好，我重新整理了一下上次的pr，为AutoMapper、AutoMapping、AutoMapping增加了Repeatable元注解，这样在使用的时候不需要将注解声明在注解内部，比如从下面的方式
```java
@AutoMappers({
        @AutoMapper(target = User.class),
        @AutoMapper(target = UserDto.class)
})

public class UserQuery {

    @AutoMappings({
            @AutoMapping(targetClass = User.class, target = "username")
            @AutoMapping(targetClass = UserDto.class, target = "username")
    })
    private String name;

    @ReverseAutoMappings({
            @ReverseAutoMapping(targetClass = User.class, source = "age"),
            @ReverseAutoMapping(targetClass = UserDto.class, source = "age")
    })
    private int age;

    public String getName() {
        return name;
    }

    public void setName(String name) {
        this.name = name;
    }

    public int getAge() {
        return age;
    }

    public void setAge(int age) {
        this.age = age;
    }
}
```
更改为下面的方式：
```java
@AutoMapper(target = User.class)
@AutoMapper(target = UserDto.class)
public class UserQuery {

    @AutoMapping(targetClass = User.class, target = "username")
    @AutoMapping(targetClass = UserDto.class, target = "username")
    private String name;

    @ReverseAutoMapping(targetClass = User.class, source = "age")
    @ReverseAutoMapping(targetClass = UserDto.class, source = "age")
    private int age;

    public String getName() {
        return name;
    }

    public void setName(String name) {
        this.name = name;
    }

    public int getAge() {
        return age;
    }

    public void setAge(int age) {
        this.age = age;
    }
}
```
通过测试得到的结果二者是一样的，都可以达到相同的目的
原因是由于虽然写法从上面的方式变为下面的方式，但是实际上在编译时获取到的注解还是AutoMappers、AutoMappings、ReverseAutoMappings，写法上的变化只是一种语法糖而已，所以不需要其他地方的调整