### PR TITLE
fix: rename springContextUtils to springContextUtils4Msp

### DIFF
--- a/mapstruct-plus-spring-boot-starter/src/main/java/io/github/linpeilie/mapstruct/MapstructAutoConfiguration.java
+++ b/mapstruct-plus-spring-boot-starter/src/main/java/io/github/linpeilie/mapstruct/MapstructAutoConfiguration.java
@@ -25,7 +25,7 @@ public class MapstructAutoConfiguration {
     }
 
     @Bean
-    public static SpringContextUtils4Msp springContextUtils() {
+    public static SpringContextUtils4Msp springContextUtils4Msp() {
         return new SpringContextUtils4Msp();
     }
 


### PR DESCRIPTION
fix https://github.com/linpeilie/mapstruct-plus/issues/167